### PR TITLE
Add Hardware Type: BetaFPV 900 Nano TX

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -380,6 +380,11 @@ enum HardwareModel {
   BETAFPV_2400_TX = 45;
   
   /*
+   * BetaFPV ExpressLRS "Nano" TX Module 900MHz with ESP32 CPU
+   */
+   BETAFPV_900_NANO_TX = 46;
+  
+  /*
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.
    */
   PRIVATE_HW = 255;


### PR DESCRIPTION
Fairly simple, this just adds a new type to the hardware types in mesh.proto for the [BetaFPV Nano 900 TX](https://betafpv.com/products/elrs-nano-tx-module)

<!-- Describe what you are intending to change -->

# What does this PR do?

<!-- Please remove or replace the issue url -->

> [Related Issue](https://github.com/meshtastic/protobufs/issues/0)

## Checklist before merging

- [ ] All top level messages commented
- [ ] All enum members have unique descriptions
